### PR TITLE
chore: disable pep8-naming

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ deps =
     {format,checkformatting}: black
     {format,checkformatting}: isort
     flake8: flake8
-    flake8: pep8-naming
+    ; flake8: pep8-naming
 changedir = reliabilityassessment
 commands =
     pytest: pytest


### PR DESCRIPTION
### Purpose
Disable the check temporarily as we discussed.

### Testing
Added a variable that will fail the check and tested that tox behaves as expected before/after.

### Time estimate
1 min
