### PR TITLE
feat: add function 'gstate'

### DIFF
--- a/reliabilityassessment/monte_carlo/gstate.py
+++ b/reliabilityassessment/monte_carlo/gstate.py
@@ -3,7 +3,7 @@ from bisect import bisect_left
 import numpy as np
 
 
-def gstate(PROBG, RATING, DERATE, PLNDST):
+def gstate(PROBG, RATING, DERATE, PLNDST, rng=np.random.default_rng()):
     """
     It samples the state of available capacity for each generator up to NUNITS
 
@@ -25,10 +25,7 @@ def gstate(PROBG, RATING, DERATE, PLNDST):
     # Vectorized operation utilizing the bisect API
     aux = {i: {0: 1, 1: d, 2: 0} for i, d in enumerate(DERATE)}
     PCTAVL = np.array(
-        [
-            aux[i][bisect_left(PROBG[i], x)]
-            for i, x in enumerate(np.random.rand(len(PROBG)))
-        ]
+        [aux[i][bisect_left(PROBG[i], x)] for i, x in enumerate(rng.random(len(PROBG)))]
     )
     AVAIL = (PCTAVL * RATING * PLNDST).reshape(-1, 1)
 

--- a/reliabilityassessment/monte_carlo/tests/test_gstate.py
+++ b/reliabilityassessment/monte_carlo/tests/test_gstate.py
@@ -1,0 +1,30 @@
+import numpy as np
+
+from reliabilityassessment.monte_carlo.gstate import gstate
+
+
+def test_gstate():
+    # arrange
+    NUNITS = 2
+    PROBG = np.array(
+        [
+            [0.2, 0.5, 1.0],
+            [0.1, 0.7, 1.0],
+        ]
+    )
+    RATING = np.array([150, 250])
+    DERATE = np.array([0.35, 0.15])
+    PLNDST = np.array([1, 1])
+    rng_42 = np.random.default_rng(seed=42)
+    # act
+    # random numbers are generated for seed 42
+    PCTAVL, AVAIL = gstate(PROBG, RATING, DERATE, PLNDST, rng=rng_42)
+    # assert
+    assert PCTAVL.size == NUNITS
+    assert AVAIL.size == NUNITS
+    # unit 1 random #: 0.7739560485559633
+    assert PCTAVL[0] == 0
+    assert AVAIL[0] == 0
+    # unit 2 random #: 0.4388784397520523
+    assert PCTAVL[1] == 0.15
+    assert AVAIL[1] == 37.5


### PR DESCRIPTION
[Pull Request doc](https://breakthrough-energy.github.io/docs/user/git_guide.html#d-pull-request)

### Purpose
Create and update function 'gstate'

### What the code is doing
It samples the state of available capacity for each generator

### Testing
manual testing. 

### Where to look
https://github.com/Breakthrough-Energy/reliability-assessment/blob/gstate/monte_carlo/gstate.py

* What files are most important?
https://github.com/Breakthrough-Energy/reliability-assessment/blob/gstate/monte_carlo/gstate.py

### Usage Example/Visuals
```python
PCTAVL, AVAIL = gstate(NUNITS, PROBG, RATING, DERATE, PLNDST)
E.g., NUNITS = 2,  each generator unit has 3 states, so the dimension of PROBG is 4-by-3, e.g., PROBG  = 
[ 
  [0.2, 0.5, 1.0],
  [0.1, 0.7, 1.0],
]

# RATING, DERATE, PLNDST are all 1D arrays, with length = NUNITS = 2 for the example here:
RATING = [150, 250] 
DERATE = [0.35, 0.15]
PLNDST  = [1, 1] 
```
**Note: The reason why a 'vanilla for loop' but not the rng.choice function or other vectorized version is adopted in this code is due to the following reasons:**
          --1) The capacity probability of each gen unit CAN BE different from each other. (That is why the PROBG array is originally designed as 2-D but not 1-D)
          --2) The rng.choice function cannot (or can but inconvenient) adapt to the situation here due to 1);

Again, the main philosophy during my current process of Fortran-Python translation/re-implementation is to:
First, ensuring
 -- 1) The overall convergence and correctness of the Monte Carlo simulation 
 -- 2) No or less re-naming of certain important arrays/variables (especially for those that are heavily used across multiple subroutines/functions)    
Then, experimenting with potential speed improvement solutions/tricks when 1) is achieved.

### Time estimate
5 - 10 min.
