### PR TITLE
test: example test for gstate

### DIFF
--- a/reliabilityassessment/monte_carlo/gstate.py
+++ b/reliabilityassessment/monte_carlo/gstate.py
@@ -3,7 +3,7 @@ from bisect import bisect_left
 import numpy as np
 
 
-def gstate(PROBG, RATING, DERATE, PLNDST):
+def gstate(PROBG, RATING, DERATE, PLNDST, rng=np.random.default_rng()):
     """
     It samples the state of available capacity for each generator up to NUNITS
 
@@ -25,10 +25,7 @@ def gstate(PROBG, RATING, DERATE, PLNDST):
     # Vectorized operation utilizing the bisect API
     aux = {i: {0: 1, 1: d, 2: 0} for i, d in enumerate(DERATE)}
     PCTAVL = np.array(
-        [
-            aux[i][bisect_left(PROBG[i], x)]
-            for i, x in enumerate(np.random.rand(len(PROBG)))
-        ]
+        [aux[i][bisect_left(PROBG[i], x)] for i, x in enumerate(rng.random(len(PROBG)))]
     )
     AVAIL = (PCTAVL * RATING * PLNDST).reshape(-1, 1)
 

--- a/reliabilityassessment/monte_carlo/tests/test_gstate.py
+++ b/reliabilityassessment/monte_carlo/tests/test_gstate.py
@@ -1,0 +1,30 @@
+import numpy as np
+
+from reliabilityassessment.monte_carlo.gstate import gstate
+
+
+def test_gstate():
+    # arrange
+    NUNITS = 2
+    PROBG = np.array(
+        [
+            [0.2, 0.5, 1.0],
+            [0.1, 0.7, 1.0],
+        ]
+    )
+    RATING = np.array([150, 250])
+    DERATE = np.array([0.35, 0.15])
+    PLNDST = np.array([1, 1])
+    rng_42 = np.random.default_rng(seed=42)
+    # act
+    # random numbers are generated for seed 42
+    PCTAVL, AVAIL = gstate(PROBG, RATING, DERATE, PLNDST, rng=rng_42)
+    # assert
+    assert PCTAVL.size == NUNITS
+    assert AVAIL.size == NUNITS
+    # unit 1 random #: 0.7739560485559633
+    assert PCTAVL[0] == 0
+    assert AVAIL[0] == 0
+    # unit 2 random #: 0.4388784397520523
+    assert PCTAVL[1] == 0.15
+    assert AVAIL[1] == 37.5


### PR DESCRIPTION
[Pull Request doc](https://breakthrough-energy.github.io/docs/user/git_guide.html#d-pull-request)

### Purpose

This example test shows a potential way for testing stochastic functions in the future.

### What the code is doing

I used your sample parameters listed in the PR https://github.com/Breakthrough-Energy/reliability-assessment/pull/11, and used an optional random number seed parameter for reproducibility:
https://numpy.org/doc/stable/reference/random/generator.html

### Testing

Ran test automatically using `pytest -vs` to collect the tests in the repo:
<img width="1255" alt="Screen Shot 2021-09-03 at 4 36 43 PM" src="https://user-images.githubusercontent.com/1626883/132074449-37ba45c7-bcaa-4495-b3f3-1720fbe985e2.png">

### Where to look

PR https://github.com/Breakthrough-Energy/reliability-assessment/pull/11 still needs to be rebased with `main`, so currently the functions from my earlier PR are included in the diff. My changes are in the files: `reliabilityassessment/monte_carlo/gstate.py` and `reliabilityassessment/monte_carlo/tests/test_gstate.py`.

### Time estimate
~15min
