### PR TITLE
feat: thetac function - subroutine generates vector THETC of bus angles

### DIFF
--- a/reliabilityassessment/monte_carlo/tests/test_thetac.py
+++ b/reliabilityassessment/monte_carlo/tests/test_thetac.py
@@ -7,7 +7,7 @@ def test_thetac():
     # arrange
     NUNITS = 3
     THET = np.array([0.3, 0.5, 0.7])
-    LT = np.array([3, 1, 2])
+    LT = np.array([2, 0, 1])
     # act
     THETC = thetac(THET, LT)
     # assert

--- a/reliabilityassessment/monte_carlo/thetac.py
+++ b/reliabilityassessment/monte_carlo/thetac.py
@@ -14,9 +14,6 @@ def thetac(THET, LT):
     NN = len(THET)
     THETC = np.zeros(NN)
 
-    # subtract 1 to account for zero indexing
-    LT = LT - 1
-
     # last array value is the "reference" bus that ALWAYS has a zero phase angle
     THETC[LT[:-1]] = THET[:-1]
     return THETC


### PR DESCRIPTION
[Pull Request doc](https://breakthrough-energy.github.io/docs/user/git_guide.html#d-pull-request)

### Purpose

This subroutine generates vector THETC of bus angles for all buses including ref bus.

### What the code is doing

Function uses the following inputs:
```
 THET - CONTAINS ANGLE AT NODE I OF THE ADM MATRIX
 THETC - cumulative sum of angles
 LT(I) CONTAINS THE ACTUAL NODE CORRESPONDING TO NODE I OF THE ADM MATRIX 
 NN - total number of nodes
```

### Testing
How did you test this change (unit/functional testing, manual testing, etc.)? 

### Usage Example/Visuals
How the code can be used and/or images of any graphs, tables or other visuals (not always applicable). 

### Time estimate
~15 min
