### PR TITLE
feat: add function sumcap

### DIFF
--- a/reliabilityassessment/monte_carlo/sumcap.py
+++ b/reliabilityassessment/monte_carlo/sumcap.py
@@ -1,0 +1,41 @@
+import numpy as np
+
+
+def sumcap(AVAIL, CAPOWN, CAPCON):
+    """
+    Determines the total available capacity for each system (area).
+
+    :param numpy.array AVAIL: array of the finalized power capacity
+                              (in nominal value) of each unit
+    :param numpy.array CAPOWN: a 2D array, the (j,i) th element means
+                               the fraction of unit i owned by area j.
+    :param numpy.array CAPCON: a 1D array of length NUINT; the CAPCON[i] means the area
+                               that the ith generator physically resides in.
+
+
+    :return: (*numpy.array *) CAPAVL -- a 2D array, the (j,i) th element means the
+                              the fraction (available) capacity of the ith generator owned
+                              by the jth area
+             (*numpy.array *) SYSOWN -- the genuine/net capacity owned by each area.
+
+             (*numpy.array *) SYSCON -- the literal capacity owned by each area.
+             (*numpy.array *) TRNSFJ -- the capacity transferred out to the rest area(s)
+                                        from the current system (area)
+    """
+
+    # Split Capacity by Ownership.
+    NOAREA, NUNITS = CAPOWN.shape
+
+    CAPAVL = np.multiply(CAPOWN, AVAIL.T)
+
+    SYSOWN = np.sum(CAPAVL, axis=1)
+
+    SYSCON = np.zeros(NOAREA)
+
+    for i in range(NUNITS):
+        j = CAPCON[i]
+        SYSCON[j] = SYSCON[j] + AVAIL[i]
+
+    TRNSFJ = SYSCON - SYSOWN
+
+    return CAPAVL, SYSOWN, SYSCON, TRNSFJ

--- a/reliabilityassessment/monte_carlo/tests/test_sumcap.py
+++ b/reliabilityassessment/monte_carlo/tests/test_sumcap.py
@@ -1,0 +1,17 @@
+import numpy as np
+
+from reliabilityassessment.monte_carlo.sumcap import sumcap
+
+
+def test_sumcap():
+    # arrange
+    AVAIL = np.array([100, 50, 150])
+    CAPOWN = np.array([[1, 0.5, 0], [0, 0.5, 1]])
+    CAPCON = np.array([0, 0, 1])
+    # act
+    CAPAVL, SYSOWN, SYSCON, TRNSFJ = sumcap(AVAIL, CAPOWN, CAPCON)
+    # assert
+    assert np.array_equal(CAPAVL, np.array([[100.0, 25.0, 0.0], [0.0, 25.0, 150.0]]))
+    assert np.array_equal(SYSOWN, np.array([125.0, 175.0]))
+    assert np.array_equal(SYSCON, np.array([150.0, 150.0]))
+    assert np.array_equal(TRNSFJ, np.array([25.0, -25.0]))


### PR DESCRIPTION
[Pull Request doc](https://breakthrough-energy.github.io/docs/user/git_guide.html#d-pull-request)

### Purpose

Function computes the total available capacity for each system (area).

### What the code is doing?

Splits unit capacity by ownership and then sums the capacity owned by each area.

Function has the following parameters:
```
NUNITS: total number of generator units
AVAIL: array of the finalized power capacity (in nominal value) of each unit
CAPOWN: a 2D array, the (j,i) element means the fraction of unit i owned by area j.
CAPCON: a 1D array of length NUINT; the CAPCON[i] means the area that the ith generator physically resides in.
```

### Testing
How did you test this change (unit/functional testing, manual testing, etc.)? 

### Usage Example/Visuals
How the code can be used and/or images of any graphs, tables or other visuals (not always applicable). 

### Time estimate
~30min