### PR TITLE
test: only run fast tests by default

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,21 @@
+import pytest
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--runslow", action="store_true", default=False, help="run slow tests"
+    )
+
+
+def pytest_configure(config):
+    config.addinivalue_line("markers", "slow: mark test as slow to run")
+
+
+def pytest_collection_modifyitems(config, items):
+    if config.getoption("--runslow"):
+        # --runslow given in cli: do not skip slow tests
+        return
+    skip_slow = pytest.mark.skip(reason="need --runslow option to run")
+    for item in items:
+        if "slow" in item.keywords:
+            item.add_marker(skip_slow)

--- a/reliabilityassessment/monte_carlo/tests/test_line_prob_sampling.py
+++ b/reliabilityassessment/monte_carlo/tests/test_line_prob_sampling.py
@@ -10,6 +10,7 @@ from reliabilityassessment.monte_carlo.line_prob_sampling import (
 
 # The following three tests are probabilistic which rely on the law of large numbers.
 # If a test failure occurs, run again and see if the test passes
+@pytest.mark.slow
 def test_lstate():
     # arrange
     NLINES = 1000000
@@ -27,6 +28,7 @@ def test_lstate():
         assert PROB[i] == pytest.approx(LNSTAT_bins[i + 1] / NLINES, 0.05)
 
 
+@pytest.mark.slow
 def test_lstate_original():
     # arrange
     NLINES = 1000000
@@ -43,6 +45,7 @@ def test_lstate_original():
         assert PROB[i] == pytest.approx(LNSTAT_bins[i + 1] / NLINES, 0.05)
 
 
+@pytest.mark.slow
 def test_generate_discrete_probability_generator():
     # arrange
     NLINES = 1000000
@@ -59,6 +62,7 @@ def test_generate_discrete_probability_generator():
         assert PROB[i] == pytest.approx(LNSTAT_bins[i + 1] / NLINES, 0.05)
 
 
+@pytest.mark.slow
 def test_lstate_benchmark(benchmark):
     # setup
     NLINES = 1000000
@@ -69,6 +73,7 @@ def test_lstate_benchmark(benchmark):
     benchmark(lstate, PROBL_mat)
 
 
+@pytest.mark.slow
 def test_lstate_original_benchmark(benchmark):
     # setup
     NLINES = 1000000
@@ -78,6 +83,7 @@ def test_lstate_original_benchmark(benchmark):
     benchmark(lstate_original, NLINES, PROBL)
 
 
+@pytest.mark.slow
 def test_discrete_prob_gen_benchmark(benchmark):
     # setup
     NLINES = 1000000


### PR DESCRIPTION
[Pull Request doc](https://breakthrough-energy.github.io/docs/user/git_guide.html#d-pull-request)

### Purpose

Allows us to decorate slow tests with `@pytest.mark.slow` and only run these tests as needed with `pytest --runslow`.

### What the code is doing

Implements the slow test marker example from pytest documentation:
https://docs.pytest.org/en/latest/example/simple.html#control-skipping-of-tests-according-to-command-line-option

### Testing

<img width="914" alt="Screen Shot 2022-05-23 at 4 09 26 PM" src="https://user-images.githubusercontent.com/1626883/169918810-e0514900-b329-4ef3-8d57-045b9b0ad2ae.png">

### Time estimate
~10 min