### PR TITLE
PR: patch 'datax' by adding missing return values

### DIFF
--- a/reliabilityassessment/data_processing/datax.py
+++ b/reliabilityassessment/data_processing/datax.py
@@ -167,6 +167,18 @@ def datax(inputB_dict):
     MXCRIT = 0  # total (maximum) number of critical units
     JCRIT = np.zeros((500,))  # critical (affecting) unit id
 
+    # Create array 'ID':
+    NUNITS = len(PROBG)
+    ID = np.zeros((NUNITS, 8), dtype=int)
+    ID[:, 0] = deepcopy(inputB_dict["ZZUD"]["NAT"])
+    ID[:, 1] = deepcopy(inputB_dict["ZZUD"]["NAT"])
+    ID[:, 2] = deepcopy(inputB_dict["ZZUD"]["NAR"])
+    ID[:, 3] = deepcopy(inputB_dict["ZZUD"]["ID"][:, 1]) - 1  # to 0-based index
+    ID[:, 4] = deepcopy(inputB_dict["ZZUD"]["ID"][:, 2])
+    ID[:, 5] = deepcopy(inputB_dict["ZZUD"]["ID"][:, 3]) - 1  # to 0-based index
+    ID[:, 6] = deepcopy(inputB_dict["ZZUD"]["ID"][:, 4])
+    ID[:, 7] = deepcopy(inputB_dict["ZZUD"]["ID"][:, 0])
+
     return (
         QTR,
         NORR,
@@ -181,6 +193,7 @@ def datax(inputB_dict):
         BN,
         SUSTAT,
         FCTERR,
+        CAPCON,
         CAPOWN,
         NOGEN,
         PROBG,
@@ -194,4 +207,5 @@ def datax(inputB_dict):
         BLPA,
         MXCRIT,
         JCRIT,
+        ID,
     )

--- a/reliabilityassessment/data_processing/tests/test_datax.py
+++ b/reliabilityassessment/data_processing/tests/test_datax.py
@@ -27,6 +27,7 @@ def test_datax():
         BN,
         SUSTAT,
         FCTERR,
+        CAPCON,
         CAPOWN,
         NOGEN,
         PROBG,
@@ -40,6 +41,7 @@ def test_datax():
         BLPA,
         MXCRIT,
         JCRIT,
+        ID,
     ) = datax(inputB_dict_nameToInt)
 
     QTR_ = np.array([13 * 168 + 0.5, 26 * 168 + 0.5, 39 * 168 + 0.5])
@@ -76,6 +78,9 @@ def test_datax():
 
     FCTERR_ = np.array([[1.0, 1.0, 1.0, 1.0, 1.0], [1.0, 1.0, 1.0, 1.0, 1.0]])
     np.testing.assert_array_equal(FCTERR_, FCTERR)
+
+    CAPCON_ = np.array([0, 1])
+    np.testing.assert_array_equal(CAPCON_, CAPCON)
 
     CAPOWN_ = np.array([[1, 0], [0, 1]])
     np.testing.assert_array_equal(CAPOWN_, CAPOWN)
@@ -138,3 +143,6 @@ def test_datax():
 
     JCRIT_ = np.zeros((500,))
     np.testing.assert_array_equal(JCRIT_, JCRIT)
+
+    ID_ = np.array([[0, 0, 0, -1, 0, -1, 0, 0], [1, 1, 1, -1, 0, -1, 0, 0]], dtype=int)
+    np.testing.assert_array_equal(ID_, ID)


### PR DESCRIPTION
[Pull Request doc](https://breakthrough-energy.github.io/docs/user/git_guide.html#d-pull-request)

### Purpose
put array 'ID' and 'CAPCON' into return values for the function 'datax'

### What the code is doing
    Reads all data except the hourly load data
    and creates appropriate arrays.

### Testing
unit test

### Where to look
https://github.com/Breakthrough-Energy/reliability-assessment/blob/datax_patch_add_array_ID/reliabilityassessment/data_processing/datax.py

https://github.com/Breakthrough-Energy/reliability-assessment/blob/datax_patch_add_array_ID/reliabilityassessment/data_processing/tests/test_datax.py

* What files are most important?

### Usage Example/Visuals
See unit test

### Time estimate
10 min